### PR TITLE
Un-break ZeroClipboard.js in browsers

### DIFF
--- a/ZeroClipboard.js
+++ b/ZeroClipboard.js
@@ -315,4 +315,7 @@ ZeroClipboard.Client.prototype = {
 	
 };
 
-module.exports = ZeroClipboard;
+if (typeof module !== "undefined") {
+	module.exports = ZeroClipboard;
+}
+


### PR DESCRIPTION
- Ensure that 'module' is defined before setting 'module.exports' to prevent
  script failing on initialization in browsers.
