### PR TITLE
Fix swf object position

### DIFF
--- a/src/javascript/ZeroClipboard.js
+++ b/src/javascript/ZeroClipboard.js
@@ -69,7 +69,9 @@ window.ZeroClipboard = {
 
 		while (obj && (obj != stopObj)) {
 			info.left += obj.offsetLeft;
+			info.left += obj.style.borderLeftWidth ? parseInt(obj.style.borderLeftWidth) : 0;
 			info.top += obj.offsetTop;
+			info.top += obj.style.borderTopWidth ? parseInt(obj.style.borderTopWidth) : 0;
 			obj = obj.offsetParent;
 		}
 


### PR DESCRIPTION
if the offsetParent has border, the position is wrong.

Using ZeroClipboard inside fancybox which has 10px border width, the swf object is -10px top/left
