### PR TITLE
Title specified with `setTitle` should take precedence over an existing "title" attribute on the DOM element targeted for gluing

### DIFF
--- a/src/javascript/ZeroClipboard.js
+++ b/src/javascript/ZeroClipboard.js
@@ -117,7 +117,7 @@ ZeroClipboard.Client.prototype = {
     }
 
     // check if the element has a title
-    if (this.domElement.getAttribute("title") != null) {
+    if (!this.title && this.domElement.getAttribute("title") != null) {
       this.title = this.domElement.getAttribute("title");
     }
 


### PR DESCRIPTION
If I glue to an element that already has a "title" attribute (with a value), that existing title [takes precedent](https://github.com/jonrohan/ZeroClipboard/blob/ebaee84d5a7325d736c44d68b5091ab0fc96e767/src/javascript/ZeroClipboard.js#L120-L122) over the title value that I set for my ZeroClipboard client:

``` js
if (this.domElement.getAttribute("title") != null) {
    this.title = this.domElement.getAttribute("title");
}
```

That is _not_ the behavior I would expect.  I would expect to see:

``` js
if (!this.title && this.domElement.getAttribute("title") != null) {
    this.title = this.domElement.getAttribute("title");
}
```
