### PR TITLE
Add a clipboard target as source of text for the copy to clipboard button

### DIFF
--- a/ZeroClipboard.js
+++ b/ZeroClipboard.js
@@ -160,7 +160,7 @@
   ZeroClipboard.prototype.setCurrent = function(element) {
     currentElement = element;
     this.reposition();
-    this.setText(this.options.text || element.getAttribute("data-clipboard-text"));
+    this.setText(this.options.text || element.getAttribute("data-clipboard-text") || document.getElementById(element.getAttribute("data-clipboard-target")).innerHTML);
     if (element.getAttribute("title")) {
       this.setTitle(element.getAttribute("title"));
     }


### PR DESCRIPTION
I'd like a simple declarative way to point to another element as the source of the text for the copy to clipboard button.

That way I don't have to muck around with the `setText` method. This PR is a very simplistic approach to it meant to start a conversation about the idea.

For example, it assumes you want `innerHTML` and not the `innerText` or the `value` attribute of the target element. We could add more options or infer this info based on the target element type.
