### PR TITLE
CONTRIBUTING.md: fix link to roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing
 
 If you find an issue, a pull request is always better than a bug report. Please fork and submit your code fixes.
 
-If you want to build some new features, we have a [roadmap.md](ZeroClipboard/blob/master/docs/roadmap.md) of features we want. You can add features you want there, or just code the feature and send a pull request.
+If you want to build some new features, we have a [roadmap.md](docs/roadmap.md) of features we want. You can add features you want there, or just code the feature and send a pull request.
 
 ### Cloning
 


### PR DESCRIPTION
Path for link to roadmap in CONTRIBUTING.md was wrong.
