### PR TITLE
fixed typo preventing the support of XHTML

### DIFF
--- a/ZeroClipboard.js
+++ b/ZeroClipboard.js
@@ -232,7 +232,7 @@
       document.body.appendChild(container);
     }
     client.htmlBridge = container;
-    client.flashBridge = container.children[0].children[9];
+    client.flashBridge = document["global-zeroclipboard-flash-bridge"] || container.children[0].lastElementChild;
   };
   ZeroClipboard.prototype.resetBridge = function() {
     this.htmlBridge.style.left = "-9999px";

--- a/src/javascript/ZeroClipboard/dom.js
+++ b/src/javascript/ZeroClipboard/dom.js
@@ -51,7 +51,7 @@ var _bridge = function () {
   }
 
   client.htmlBridge = container;
-  client.flashBridge = container.children[0].children[9];
+  client.flashBridge = document["global-zeroclipboard-flash-bridge"] || container.children[0].lastElementChild;
 };
 
 /*


### PR DESCRIPTION
`<param name="scale" value="exactfit">` missed the "/" necessary for ZeroClipboard to work with XHTML
