### PR TITLE
Start using Semantic Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ see [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Releases
 
+After version [1.1.7](docs/releases.md#zeroclipboard-117) ZeroClipboard uses [semantic versioning](http://semver.org/)
+
 see [releases.md](docs/releases.md)
 
 ## Roadmap


### PR DESCRIPTION
Until now, I've just been incrementing the version number based on release. Recently I heard about [semantic versioning](http://semver.org/) and realized I'm doing it wrong. I think after cutting 1.1.7 we should start using semantic versioning.

The tl;dr version of semantic versioning is 
- **1.1.Z** Z is for bug fixes
- **1.Y.7** Y is for features
- **X.1.7** X is for backwards compat breaking changes to the api

At first I thought it may be smart to come up with a better branch deploy strategy, but that ends up making things more complex than it needs to be. I think we can keep doing like we're doing. `master` is considered alpha changes. and when we fix bugs, features, or major revisions we'll update the numbers accordingly. This mainly helps with people who want auto updating of zeroclipboard. The can rely on `1.1.*` not breaking their code, but just fixing bugs for example.

@JamesMGreene 
