### PR TITLE
Update dom.js

### DIFF
--- a/src/javascript/ZeroClipboard/dom.js
+++ b/src/javascript/ZeroClipboard/dom.js
@@ -17,7 +17,7 @@ var _bridge = function () {
         <param name=\"loop\" value=\"false\"/> \
         <param name=\"menu\" value=\"false\"/> \
         <param name=\"quality\" value=\"best\"/> \
-        <param name=\"wmode\" value=\"window\"/> \
+        <param name=\"wmode\" value=\"transparent\"/> \
         <param name=\"FlashVars\" value=\"" + _vars(client.options) + "\"/> \
       </object>";
 


### PR DESCRIPTION
- classid and all of the embed tag were invalid html, now it's OK for XHTML-strict and HTML5
- I set the CSS for WxH to 100%/100% although inherit/inherit is also an option.
- I placed allowScriptAccess on top as it's a permission thing, and in some players need to be there.
- I set it to noscale to noscale as it will leave content alone and cropping then is possible.
- wmode transparent and BG ffffff is a conflict, I removed the BG.
- having wmode set to "window" solved an actual pesky mysterious bug when using the hoverClass (no toggle on mouseleave):
  http://stackoverflow.com/a/6050201/1399595
- I wrote flashvars as FlashVars, even though that probably only benefits older players.
