### PR TITLE
Fix reading zIndex under chrome

### DIFF
--- a/src/javascript/ZeroClipboard/utils.js
+++ b/src/javascript/ZeroClipboard/utils.js
@@ -10,7 +10,7 @@ var _getStyle = function (el, prop) {
   if (el.currentStyle)
     y = el.currentStyle[prop];
   else if (window.getComputedStyle)
-    y = document.defaultView.getComputedStyle(el, null).getPropertyValue(prop);
+    y = document.defaultView.getComputedStyle(el, null).getPropertyValue(prop.replace(/([A-Z])/g, "-$1").toLowerCase());
 
   if (y == "auto" && prop == "cursor") {
     var possiblePointers = ["a"];


### PR DESCRIPTION
For me on chrome 26 the object returned by getComputedStyle() has
properties with names as in css ('z-index') not like the javascript
style properties ('zIndex') so we need to convert to look up the
z-index correctly.
