### PR TITLE
Fixes for my Linux VM build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # set an environment variable to override this to your location. export SWF_COMPILER = /My/Location/bin/mxmlc
 SWF_COMPILER ?= /Applications/Adobe\ Flash\ Builder\ 4.7/sdks/4.6.0/bin/mxmlc -static-link-runtime-shared-libraries=true
 
-NODE_PATH ?= ./node_modules
+NODE_PATH = ./node_modules
 JS_COMPILER = $(NODE_PATH)/uglify-js/bin/uglifyjs
 JS_BEAUTIFIER = $(NODE_PATH)/uglify-js/bin/uglifyjs -b -i 2 -nm -ns
 JS_TEST = $(NODE_PATH)/nodeunit/bin/nodeunit

--- a/test/client.js
+++ b/test/client.js
@@ -109,7 +109,7 @@ exports.client = {
 
     zeroClipboard.dispatch("datarequested", { flashVersion: "MAC 11,0,0" });
 
-    test.equal(clip.options.text, "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"+
+    test.equal(clip.options.text.replace(/\r\n/g, '\n'), "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"+
     "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n"+
     "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"+
     "consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"+
@@ -130,7 +130,7 @@ exports.client = {
 
     zeroClipboard.dispatch("datarequested", { flashVersion: "MAC 11,0,0" });
 
-    test.equal(clip.options.text, "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"+
+    test.equal(clip.options.text.replace(/\r\n/g, '\n'), "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"+
     "tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n"+
     "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"+
     "consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"+


### PR DESCRIPTION
I had to make minor changes to these 2 files in order to get the build working on my new Linux VM.

**Explanations:**
1. I can't use the globally set "NODE_PATH" environment variable because it is set to a 3-directory resolver value (like "PATH"): `/usr/lib/nodejs:/sr/lib/node_modules:/usr/share/javascript` but tries to use that whole value as the absolute path.
2. Had 2 nodeunit tests failing due to `\r\n` vs. `\n`.  I find that peculiar since I'm using a Linux VM on a Windows box but oh well.
