### PR TITLE
Update client.js to no longer need the html bridge if flash doesn't exis...

### DIFF
--- a/src/javascript/ZeroClipboard/client.js
+++ b/src/javascript/ZeroClipboard/client.js
@@ -25,7 +25,12 @@ var ZeroClipboard = function (elements, options) {
   this.handlers = {};
 
   // setup the flash->Javascript bridge
-  if (ZeroClipboard.detectFlashSupport()) _bridge();
+  if (ZeroClipboard.detectFlashSupport()) {
+     _bridge();
+  } else {
+    // if flash doesn't exist, we don't want the bridge to fire mouseovers, it doesn't need to exist anymore.
+     ZeroClipboard.prototype._singleton.destroy()
+  }
 
 };
 


### PR DESCRIPTION
I ran into a bug where hovering over an element in a browser without flash would cause a javascript error when it tried to reposition the non-existant bridge.

It's happening because we glue() the bridge when we create the singleton, but do that before flash is detected. If flash doesn't exist, mouseover events still fire.

Here's a fix that destroy()s ZeroClipboard if detectFlash doesn't exist.
