### PR TITLE
Fix ZeroClipboard when used in CommonJS environment

### DIFF
--- a/src/javascript/end.js
+++ b/src/javascript/end.js
@@ -1,11 +1,10 @@
+window.ZeroClipboard = ZeroClipboard; // Needed to communicate with swf
 if (typeof module !== "undefined") {
   module.exports = ZeroClipboard;
 } else if (typeof define === "function" && define.amd) {
   define(function() {
     return ZeroClipboard;
   });
-} else {
-  window.ZeroClipboard = ZeroClipboard;
 }
 
 })();


### PR DESCRIPTION
ZeroClipboard's swf expects a ZeroClipboard global to communicate. When using in a module environment (I'm using CommonJS with RequireJS) this breaks, since everything is wrapped in a closure. This change simply always injects the global implicitly.
