### PR TITLE
make on and off event methodes chainable

### DIFF
--- a/src/javascript/ZeroClipboard/client.js
+++ b/src/javascript/ZeroClipboard/client.js
@@ -38,7 +38,7 @@ var currentElement,      // Keep track of the current element that is being hove
  * This will put the global flash object on top of the current object and set
  * the text and title from the html object.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.setCurrent = function (element) {
 
@@ -64,7 +64,7 @@ ZeroClipboard.prototype.setCurrent = function (element) {
 /*
  * Sends a signal to the flash object to set the clipboard text.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.setText = function (newText) {
   if (newText && newText !== "") {
@@ -78,7 +78,7 @@ ZeroClipboard.prototype.setText = function (newText) {
 /*
  * Adds a title="" attribute to the htmlBridge to give it tooltip capabiities
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.setTitle = function (newTitle) {
   if (newTitle && newTitle !== "") this.htmlBridge.setAttribute("title", newTitle);
@@ -89,7 +89,7 @@ ZeroClipboard.prototype.setTitle = function (newTitle) {
 /*
  * Sends a signal to the flash object to change the stage size.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.setSize = function (width, height) {
   if (this.ready()) this.flashBridge.setSize(width, height);
@@ -103,7 +103,7 @@ ZeroClipboard.prototype.setSize = function (width, height) {
  * Sends a signal to the flash object to display the hand cursor if true.
  * Updates the value of the `forceHandCursor` option.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.setHandCursor = function (enabled) {
   enabled = typeof enabled === "boolean" ? enabled : !!enabled;

--- a/src/javascript/ZeroClipboard/dom.js
+++ b/src/javascript/ZeroClipboard/dom.js
@@ -72,7 +72,7 @@ var _bridge = function () {
 /*
  * Reset the html bridge to be hidden off screen and not have title or text.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.resetBridge = function () {
   this.htmlBridge.style.left = "-9999px";
@@ -103,7 +103,7 @@ ZeroClipboard.prototype.ready = function () {
  *
  * Reposition the flash object, if the page size changes.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.reposition = function () {
 

--- a/src/javascript/ZeroClipboard/event.js
+++ b/src/javascript/ZeroClipboard/event.js
@@ -11,7 +11,7 @@ ZeroClipboard.dispatch = function (eventName, args) {
 /*
  * Add an event to the client.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.on = function (eventName, func) {
   // add user event listener for event
@@ -35,7 +35,7 @@ ZeroClipboard.prototype.addEventListener = ZeroClipboard.prototype.on;
 /*
  * Remove an event from the client.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.off = function (eventName, func) {
   // remove user event listener for event
@@ -137,7 +137,7 @@ ZeroClipboard.prototype.receiveEvent = function (eventName, args) {
 /*
  * Register new element(s) to the object.
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.glue = function (elements) {
 
@@ -161,7 +161,7 @@ ZeroClipboard.prototype.glue = function (elements) {
 /*
  * Unregister the clipboard actions of an element on the page
  *
- * returns nothing
+ * returns object instance
  */
 ZeroClipboard.prototype.unglue = function (elements) {
 


### PR DESCRIPTION
Hey,

would be great if the on and off methodes are chainable to do instance.on().on() instead of instance.on() instance.on()

Best
Tobi
