### PR TITLE
Had a situation where I needed to destroy the instance and the only example appeared only once. 

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,8 +2,8 @@
 
 A list of the ZeroClipboard instance API
 
-#### config
+#### .config
 ZeroClipboard.config(); Creates defaults for ZeroClipboard instance.
 
-#### destroy
+#### .destroy
 ZeroClipboard.destroy(); Destroys instance of ZeroClipboard.


### PR DESCRIPTION
Condensing all the instance methods might help someone looking for the same thing in the future.
