### PR TITLE
Adding dependency badges via DavidDM

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,6 +25,7 @@ module.exports = function(grunt) {
         jshintrc: true
       },
       Gruntfile: ["Gruntfile.js"],
+      component: ["index.js"],
       js: ["src/js/**/*.js", "!src/js/start.js", "!src/js/end.js"],
       test: ["test/**/*.js"],
       dist: ["dist/*.js", "!dist/*.min.js"]
@@ -277,7 +278,7 @@ module.exports = function(grunt) {
 
 
   // Task aliases and chains
-  grunt.registerTask("jshint-prebuild", ["jshint:Gruntfile", "jshint:js", "jshint:test"]);
+  grunt.registerTask("jshint-prebuild", ["jshint:Gruntfile", "jshint:component", "jshint:js", "jshint:test"]);
   grunt.registerTask("prep-flash",      ["clean:flash", "concat:flash"]);
   grunt.registerTask("validate",        ["jshint-prebuild", "prep-flash", "flexpmd"]);
   grunt.registerTask("build",           ["clean", "concat", "jshint:dist", "uglify", "mxmlc", "template", "chmod"]);

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# WARNING
-**This `master` branch contains the `v2.x` codebase for ZeroClipboard! If you
-want to see the `v1.x` codebase, please see the [`1.x-master`](https://github.com/zeroclipboard/zeroclipboard/tree/1.x-master) branch instead.**
+### WARNING
+**This `master` branch contains the `v2.x` codebase for ZeroClipboard! For the `v1.x` codebase, see the [`1.x-master`](https://github.com/zeroclipboard/zeroclipboard/tree/1.x-master) branch instead.**
 
 
-# ZeroClipboard
+# ZeroClipboard  [![Build Status](https://secure.travis-ci.org/zeroclipboard/zeroclipboard.png?branch=master)](https://travis-ci.org/zeroclipboard/zeroclipboard)  [![dependencies Status](https://david-dm.org/zeroclipboard/zeroclipboard.svg?theme=shields.io)](https://david-dm.org/zeroclipboard/zeroclipboard)  [![devDependencies Status](https://david-dm.org/zeroclipboard/zeroclipboard/dev-status.svg?theme=shields.io)](https://david-dm.org/zeroclipboard/zeroclipboard#info=devDependencies)
 
 The ZeroClipboard library provides an easy way to copy text to the clipboard using an invisible [Adobe Flash](http://en.wikipedia.org/wiki/Adobe_Flash) movie and a [JavaScript](http://en.wikipedia.org/wiki/JavaScript) interface. The "Zero" signifies that the library is invisible and the user interface is left entirely up to you. 
 
@@ -85,8 +84,3 @@ see [releases](https://github.com/zeroclipboard/zeroclipboard/releases)
 ## Roadmap
 
 see [roadmap.md](docs/roadmap.md)
-
-
-## Last Build
-
-[![Build Status](https://secure.travis-ci.org/zeroclipboard/zeroclipboard.png?branch=master)](https://travis-ci.org/zeroclipboard/zeroclipboard)

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,6 +1,5 @@
-# WARNING
-**This `master` branch contains the `v2.x` codebase for ZeroClipboard! If you
-want to see the `v1.x` codebase, please see the [`1.x-master`](https://github.com/zeroclipboard/zeroclipboard/tree/1.x-master) branch instead.**
+### WARNING
+**This `master` branch contains the `v2.x` codebase for ZeroClipboard! For the `v1.x` codebase, see the [`1.x-master`](https://github.com/zeroclipboard/zeroclipboard/tree/1.x-master) branch instead.**
 
 
 # Overview

--- a/index.js
+++ b/index.js
@@ -1,31 +1,29 @@
+/*jshint node:true */
 
-/**
- * Module exports.
- */
 
+// Module exports
 exports = module.exports = setup;
 
-/**
- * Module dependencies.
- */
+// Module dependencies
+var http = require("http");
+var send = require("send");
 
-var http = require('http');
-var send = require('send');
+
 var root = __dirname;
-var swf = '/ZeroClipboard.swf';
+var swf = "/ZeroClipboard.swf";
 
-function setup () {
+function setup() {
   return http.createServer(onReq);
 }
 
-function onReq (req, res) {
+function onReq(req, res) {
   send(req, swf)
     .root(root)
-    .on('error', onError)
+    .on("error", onError)
     .pipe(res);
 }
 
-function onError (err) {
+function onError(err) {
   res.statusCode = err.status || 500;
   res.end(err.message);
 }

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
   "devDependencies": {
     "flex-sdk": "~4.6.0-0",
     "flexpmd": "^1.3.0-1",
-    "grunt": "^0.4.4",
+    "grunt": "^0.4.5",
     "grunt-chmod": "^1.0.3",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-concat": "^0.4.0",
-    "grunt-contrib-connect": "^0.7.1",
+    "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt-contrib-qunit": "^0.4.0",
-    "grunt-contrib-uglify": "^0.4.0",
+    "grunt-contrib-qunit": "^0.5.1",
+    "grunt-contrib-uglify": "^0.5.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-flexpmd": "^0.1.2",
     "grunt-mxmlc": "^0.5.1",
@@ -59,7 +59,7 @@
     "jquery": "^1.11.1",
     "qunit-composite": "^1.0.1",
     "qunitjs": "^1.14.0",
-    "spm": "^3.0.0"
+    "spm": "^3.0.1"
   },
   "main": "./dist/ZeroClipboard.js",
   "component": {


### PR DESCRIPTION
Adding dependency badges via [David](https://david-dm.org/).

Fixes #418.
