### PR TITLE
Only include dist/ in the bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,10 @@
   "authors": [{"name":"Jon Rohan","url":"http://jonrohan.me/"},{"name":"James M. Greene","email":"james.m.greene@gmail.com","url":"http://jamesgreene.net/"}],
   "homepage": "http://zeroclipboard.org/",
   "repository": {"type":"git","url":"https://github.com/zeroclipboard/zeroclipboard.git"},
-  "location": "git://github.com/zeroclipboard/zeroclipboard.git"
+  "location": "git://github.com/zeroclipboard/zeroclipboard.git",
+  "ignore": [
+    "*",
+    "!/bower.json",
+    "!/dist/**"
+  ]
 }


### PR DESCRIPTION
None of the other files are needed by consumers of this package.
