### PR TITLE
Issue 472 zero clipboard.min.map

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -86,21 +86,25 @@ ZeroClipboard.config( { swfPath: "http://YOURSERVER/path/ZeroClipboard.swf" } );
 ```
 
 #### Using the minified library
-If you intend use the minified version of ZeroClipboard, you may also wish to include the sourcemap to be able to debug as unminified Javascript in your browser dev tools.
-For example:
+If you intend to use the minified version of ZeroClipboard, you may also wish to include the sourcemap to be able to debug as unminified Javascript in your browser dev tools.
+The following example demonstrates including the sourcemap:
 ```html
 <script type="text/javascript" src="ZeroClipboard.min.js"></script>
 <script type="text/javascript" src="ZeroClipboard.min.map"></script>
 ```
 The sourcemap is not required for normal operation and typically will not be requested by the browser unless the dev tools are open. If you **_do not_** include the sourcemap you may see warnings in your Javascript console.
-Safari
+
+_JavaScript console in Safari_
 ```javascript
 [Error] Failed to load resource: the server responded with a status of 404 (Not Found) (ZeroClipboard.min.map, line 0)
 ```
-Firefox
-```
+
+_JavaScript console in Firefox_
+```javascript
 http://YOURSERVER/path/ZeroClipboard.min.js is being assigned a //# sourceMappingURL, but already has one
 ```
+
+You may not see any message in Chrome
 
 ## Clients
 


### PR DESCRIPTION
Added some additional clarification for use of the source map with the minified version of the library. I ran into some confusion with this, while it was a user error, perhaps others would find this documentation useful.
