### PR TITLE
license should be the type of license

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "clip",
     "clippy"
   ],
-  "license": "https://github.com/zeroclipboard/zeroclipboard/blob/master/LICENSE",
+  "license": "MIT",
   "authors": [
     {
       "name": "Jon Rohan",


### PR DESCRIPTION
Follow convention to make it easier for automated license checking utilities to determine which license is used. The license property in bower.json should be the type of license, in this case "MIT", instead of the URL of the license file.