### PR TITLE
Require robloach/component-installer for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
   "name": "zeroclipboard/zeroclipboard",
   "description": "The ZeroClipboard library provides an easy way to copy text to the clipboard using an invisible Adobe Flash movie and a JavaScript interface.",
   "type": "component",
+  "require": {
+    "robloach/component-installer": "*"
+  },
   "keywords": [
     "flash",
     "clipboard",


### PR DESCRIPTION
[robloach/component-installer](https://github.com/RobLoach/component-installer) wasn't added to `require` in #525. This adds it.

The installer needs to be required per https://github.com/RobLoach/component-installer#creating-a-component. Requiring it adds a build step that creates a `components` directory in the root of the project with a `zeroclipboard` directory that contains all files listed in `extra.component`.

This functionality is only needed for those that are using the "component" functionality for the first time. Once [robloach/component-installer](https://github.com/RobLoach/component-installer) is installed in a project by another package, it works for all other packages (such as this one) as well.

---

To make this available now without doing a full-fledged release, I recommend merging this manually into a `v2.2.0` branch, tagging that commit as `v2.2.1`, and then merging the `v2.2.0` branch back into `master`. This will make it possible take advantage of installing via packagist now, rather than waiting for the next release. Something along the lines of:

```bash
# Checkout tag v2.2.0
git checkout v2.2.0 &&
# Create new branch for v2.2.0 release
git checkout -b bv2.2.0 &&
# Merge this PR
git merge 3cc11b584b0f1d4e0fc064529fe74ddb384af9a7 &&
# Merge v2.2.0 branch back into master
git checkout master &&
git merge bv2.2.0
```

Then:

1. Push both `master` and `bv2.2.0` to this repo
2. Tag the tip of the `bv2.2.0` branch as `v2.2.1`
3. Delete the `bv2.2.0` branch, if you wish. Alternatively, keep it around to make smaller patches to until `v2.3.0` is released.