### PR TITLE
Prevent "TypeError styles = null" error in Firefox

### DIFF
--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -1681,6 +1681,11 @@ var _isElementVisible = function(el) {
   }
 
   var styles = _getComputedStyle(el, null);
+  
+  if (!styles) {
+    return false;
+  }
+
   var hasCssHeight = _parseFloat(styles.height) > 0;
   var hasCssWidth = _parseFloat(styles.width) > 0;
   var hasCssTop = _parseFloat(styles.top) >= 0;


### PR DESCRIPTION
I'm getting errors in the latest Firefox only where "styles is null".  It's referring to line 1629 on the latest ZeroClipboard (https://github.com/zeroclipboard/zeroclipboard/blob/master/dist/ZeroClipboard.js): `var hasCssHeight = _parseFloat(styles.height) > 0;`

In my tests between Chrome (where there is no error) and Firefox, it seems like Firefox is calling _isElementVisible() on load.  It passes an object in but it's not a HTML element, and so `_getComputedStyle` isn't returning anything.

Adding this little extra check fixed the issue for me in my local build.