### PR TITLE
Check length of scripts collection before using it

### DIFF
--- a/src/js/shared/private.js
+++ b/src/js/shared/private.js
@@ -248,7 +248,7 @@ var _getCurrentScriptUrl = function() {
   }
 
   // If `script` elements have the `readyState` property in this browser
-  if ("readyState" in scripts[0]) {
+  if ("readyState" in (scripts[0] || document.createElement("script"))) {
     for (i = scripts.length; i--; ) {
       if (scripts[i].readyState === "interactive" && (jsPath = scripts[i].src)) {
         return jsPath;


### PR DESCRIPTION
The current code expects the collection of scripts to be populated. However that is not the case when it runs in a JS interpreter that has nothing in the DOM.

It may happen when running ScalaJS tests in Rhino.

Check this thread to see more details: https://groups.google.com/d/msg/mozilla-rhino/Ooir-2R29-w/VRc1CWogXIcJ
