### PR TITLE
Clarified location of swf file

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -96,7 +96,7 @@ To use the library, simply include the following JavaScript file in your page:
 ```
 
 You also need to have the "`ZeroClipboard.swf`" file available to the browser.  If this file is
-located in the same directory as your web page, then it will work out of the box.  However, if the
+located in the same directory as your ZeroClipboard.js files, then it will work out of the box.  However, if the
 SWF file is hosted elsewhere, you need to set the URL like this (place this code _after_ the script
 tag):
 


### PR DESCRIPTION
Previously discussed with @jonrohan...
In order for it to work "out of the box," the .swf file must be in the same folder as the .js files. The current description of "the same folder as your web page" could be understood as the root site folder, which will not work "out of the box." 