### PR TITLE
Re-worded the number of ways to set copy text

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -160,7 +160,7 @@ see the [api/ZeroClipboard.Core.md](api/ZeroClipboard.Core.md) documentation ins
 
 ### Text To Copy
 
-Setting the clipboard text can be done in 4 ways:
+Setting the clipboard text can be done in a variety of ways:
 
 1. Add a `copy` event handler in which you call `event.clipboardData.setData` to set the appropriate data. This event is triggered every time ZeroClipboard tries to inject into the clipboard. Example:
 


### PR DESCRIPTION
The current instructions.md says there are 4 ways to set the copy text, but then it goes on to list 5 ways to do it.

I propose for it to say "a variety of ways" so that it:
1. Fixes the current error (there are 5 ways, not 4)
2. It doesn't require the number to be changed in the future if/when a new method of setting the copy text is added.