### PR TITLE
Updating the contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,91 +1,69 @@
-Contributing
-==============
+## Contributing
 
-If you find an issue, submitting a pull request is always better than a bug report! Please fork and submit your code fixes.
+[issues]: https://github.com/zeroclipboard/zeroclipboard/issues
 
-If you want to build some new features, we have a [roadmap.md](docs/roadmap.md) of features we want. You can add features you want there, or just code the feature and send a pull request.
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 
-### Cloning
+## Using the issue tracker
 
-```sh
-$ git clone https://github.com/zeroclipboard/zeroclipboard.git
-$ cd zeroclipboard/
-$ npm install -g grunt-cli
-$ npm install
-$ grunt
-```
+The [issue tracker](issues) is the preferred channel for [bug reports](#bug-reports), [features requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
 
-### Developing
+* Please **do not** use the issue tracker for personal support requests.
+* Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
-```sh
-$ npm install
-$ grunt
-```
+## Bug reports
 
-### Testing
+A bug is a _demonstrable problem_ that is caused by the code in the repository. Good bug reports are extremely helpful, so thanks!
 
-```sh
-$ grunt test
-```
+Guidelines for bug reports:
 
-### Labels structure
+1. **Use the GitHub issue search** &mdash; check if the issue has already been reported.
 
-It's not required to label your issue or pull request, but here is the structure of how we organize them.
+2. **Check if the issue has been fixed** &mdash; try to reproduce it using the latest `master` or development branch in the repository.
 
-- OS
-  - All OSes _(may be implicit)_
-  - Android
-  - Windows
-  - Mac OSX
-  - Linux
-  - iOS
-- Browser
-  - All Browsers _(may be implicit)_
-  - IE
-  - Firefox
-  - Safari
-  - Chrome/Opera
-  - Android Browser
-  - Other Browser
-- Platform #207de5
-  - Flash
-  - JS
-  - CSS
-  - HTML
-  - Events
-  - API
-- Type 
-  - Security
-  - Bug
-  - Enhancement
-  - Feature
-  - Optimization
-  - Infrastructure
-  - Documentation
-  - Question
-  - Discussion
-  - Testing
-- Change Severity (SemVer)
-  - Major
-  - Minor
-  - Patch
-- Active Status
-  - In Progress
-- Inactive Status
-  - More Info Required
-  - Help Wanted
-- Closed Status #d3d3d3
-  - Resolved _(may be implicit by Closed state without other "Closed" labels but could be nice for querying)_
-  - Invalid
-  - Duplicate
-  - WontFix
-- Meta (???)
-  - Easy Pickins
-- Integration
-  - jQuery UI
-  - Bootstrap
-  - Module Loaders
-  - Other Integration
-- External Limitations #000000
-  - HTML TopLayer
-  - Security Restriction
+A good bug report shouldn't leave others needing to chase you up for more information. Please try to be as detailed as possible in your report. What is your environment? What steps will reproduce the issue? What browser(s) and OS experience the problem? Do other browsers show the bug differently? What would you expect to be the outcome? All these details will help people to fix any potential bugs.
+
+Example:
+
+> Short and descriptive example bug report title
+>
+> A summary of the issue and the browser/OS environment in which it occurs. If
+> suitable, include the steps required to reproduce the bug.
+>
+> 1. This is the first step
+> 2. This is the second step
+> 3. Further steps, etc.
+>
+> Any other information you want to share that is relevant to the issue being reported. This might include the lines of code that you have identified as causing the bug, and potential solutions (and your opinions on their merits).
+
+## Feature requests
+
+Feature requests are welcome. But take a moment to find out whether your idea fits with the scope and aims of the project. It's up to *you* to make a strong case to convince the project's developers of the merits of this feature. Please provide as much detail and context as possible.
+
+ we have a [roadmap.md](docs/roadmap.md) of features we want. You can add features you want there, or just code the feature and send a pull request.
+
+
+## Pull requests
+
+Good pull requests—patches, improvements, new features—are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
+
+**Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's developers might not want to merge into the project.
+
+Adhering to the following process is the best way to get your work included in the project:
+
+1. Fork and clone the repository
+2. Create a new branch: `git checkout -b my-branch-name`
+3. Make your change, add tests, and make sure the tests still pass
+4. Push to your fork and [submit a pull request](https://help.github.com/articles/creating-a-pull-request/)
+5. Pat your self on the back and wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+## Resources
+
+- [Contributing to Open Source on GitHub](https://guides.github.com/activities/contributing-to-open-source/)
+- [Using Pull Requests](https://help.github.com/articles/using-pull-requests/)
+- [GitHub Help](https://help.github.com)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,33 @@ This is achieved by automatically floating the invisible movie on top of a [DOM]
 
 Suggestions welcome read over the [contributing](/CONTRIBUTING.md) guidelines.
 
+## Setup
+
+To setup the project for local development start with these commands in your terminal.
+
+```sh
+$ git clone https://github.com/zeroclipboard/zeroclipboard.git
+$ cd zeroclipboard/
+$ npm install -g grunt-cli
+$ npm install
+$ grunt
+```
+
+## Development
+
+Before submitting a pull request you'll need to validate, build, and test your code. Run the default grunt task in your terminal.
+
+```sh
+$ grunt
+```
+
+## Testing
+
+If you just want to run the tests, run grunt test.
+
+```sh
+$ grunt test
+```
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The ZeroClipboard library provides an easy way to copy text to the clipboard usi
 
 This is achieved by automatically floating the invisible movie on top of a [DOM](http://en.wikipedia.org/wiki/Document_Object_Model) element of your choice. Standard mouse events are even propagated out to your DOM element, so you can still have rollover and mousedown effects.
 
+Suggestions welcome read over the [contributing](/CONTRIBUTING.md) guidelines.
+
 
 ## Limitations
 
@@ -63,7 +65,6 @@ Here is a working [test page](http://zeroclipboard.org/#demo) where you can try 
 
 To test the page [demo page](http://zeroclipboard.org/#demo) locally, clone the [website repo](https://github.com/zeroclipboard/zeroclipboard.org).
 
-
 ## Support
 
 This library is fully compatible with Flash Player 11.0.0 and above, which requires
@@ -77,18 +78,17 @@ ZeroClipboard `v2.x` is expected to work in IE9+ and all of the evergreen browse
 Although support for IE7 & IE8 was officially dropped in `v2.0.0`, it was actually
 still _technically_ supported through `v2.0.2`.
 
-## Contributing
-
-see [CONTRIBUTING.md](CONTRIBUTING.md)
-
-
 ## Releases
 
 Starting with version [1.1.7](https://github.com/zeroclipboard/zeroclipboard/releases/tag/v1.1.7), ZeroClipboard uses [semantic versioning](http://semver.org/).
 
 see [releases](https://github.com/zeroclipboard/zeroclipboard/releases)
 
+## Related
 
-## Roadmap
+* [jquery.zeroclipboard](https://github.com/zeroclipboard/jquery.zeroclipboard)
+* [zeroclipboard-rails](https://github.com/zeroclipboard/zeroclipboard-rails)
 
-see [roadmap.md](docs/roadmap.md)
+## License
+
+MIT &copy; [James M. Greene](http://greene.io/) [Jon Rohan](http://jonrohan.codes)


### PR DESCRIPTION
I felt like our contribution guidelines were a little bit vague, and were leaving us open to filling more support requests for old versions or jquery plugins.

I wanted to update it with some guidelines I like to use in most of my projects https://github.com/jonrohan/oss-template This was riff'd from bootstrap's contributing.md file.

-- 

- [ ] :+1: ? @JamesMGreene 