### PR TITLE
Add check for native clipboard support and code to use it, fixes #171

### DIFF
--- a/src/js/core/api.js
+++ b/src/js/core/api.js
@@ -209,3 +209,11 @@ ZeroClipboard.blur = ZeroClipboard.deactivate = function() {
 ZeroClipboard.activeElement = function() {
   return _activeElement.apply(this, _args(arguments));
 };
+
+/**
+* The implementation property gets set to 'native' or 'flash' respectively
+* to show whether we use the browser's built-in clipboard API or a Flash
+* overlay. Some test scripts use this information to skip irrelevant tests.
+*/
+
+ZeroClipboard.implementation = _nativeClipboardAPI ? "native" : "flash";

--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -248,42 +248,46 @@ var _emit = function(event) {
  * @private
  */
 var _create = function() {
-  // Make note of the most recent sandbox assessment
-  var previousState = _flashState.sandboxed;
+  if(!_nativeClipboardAPI) {
+    // This browser does not support the Clipboard API
+    // We fall back to using Flash..
+    // Make note of the most recent sandbox assessment
+    var previousState = _flashState.sandboxed;
 
-  // Always reassess the `sandboxed` state of the page at important Flash-related moments
-  _detectSandbox();
+    // Always reassess the `sandboxed` state of the page at important Flash-related moments
+    _detectSandbox();
 
-  // Setup the Flash <-> JavaScript bridge
-  if (typeof _flashState.ready !== "boolean") {
-    _flashState.ready = false;
-  }
-
-  // If the page is newly sandboxed (or newly understood to be sandboxed), inform the consumer
-  if (_flashState.sandboxed !== previousState && _flashState.sandboxed === true) {
-    _flashState.ready = false;
-    ZeroClipboard.emit({ type: "error", name: "flash-sandboxed" });
-  }
-  else if (!ZeroClipboard.isFlashUnusable() && _flashState.bridge === null) {
-    var maxWait = _globalConfig.flashLoadTimeout;
-    if (typeof maxWait === "number" && maxWait >= 0) {
-      _flashCheckTimeout = _setTimeout(function() {
-        // If it took longer than `_globalConfig.flashLoadTimeout` milliseconds to receive
-        // a `ready` event, so consider Flash "deactivated".
-        if (typeof _flashState.deactivated !== "boolean") {
-          _flashState.deactivated = true;
-        }
-        if (_flashState.deactivated === true) {
-          ZeroClipboard.emit({ "type": "error", "name": "flash-deactivated" });
-        }
-      }, maxWait);
+    // Setup the Flash <-> JavaScript bridge
+    if (typeof _flashState.ready !== "boolean") {
+      _flashState.ready = false;
     }
 
-    // If attempting a fresh SWF embedding, it is safe to ignore the `overdue` status
-    _flashState.overdue = false;
+    // If the page is newly sandboxed (or newly understood to be sandboxed), inform the consumer
+    if (_flashState.sandboxed !== previousState && _flashState.sandboxed === true) {
+      _flashState.ready = false;
+      ZeroClipboard.emit({ type: "error", name: "flash-sandboxed" });
+    }
+    else if (!ZeroClipboard.isFlashUnusable() && _flashState.bridge === null) {
+      var maxWait = _globalConfig.flashLoadTimeout;
+      if (typeof maxWait === "number" && maxWait >= 0) {
+        _flashCheckTimeout = _setTimeout(function() {
+          // If it took longer than `_globalConfig.flashLoadTimeout` milliseconds to receive
+          // a `ready` event, so consider Flash "deactivated".
+          if (typeof _flashState.deactivated !== "boolean") {
+            _flashState.deactivated = true;
+          }
+          if (_flashState.deactivated === true) {
+            ZeroClipboard.emit({ "type": "error", "name": "flash-deactivated" });
+          }
+        }, maxWait);
+      }
 
-    // Embed the SWF
-    _embedSwf();
+      // If attempting a fresh SWF embedding, it is safe to ignore the `overdue` status
+      _flashState.overdue = false;
+
+      // Embed the SWF
+      _embedSwf();
+    }
   }
 };
 

--- a/src/js/core/state.js
+++ b/src/js/core/state.js
@@ -16,6 +16,24 @@ var _pageIsFramed = (function() {
 
 
 /**
+ * Check this web browser's native Clipboard API implementation status
+ * @private
+ */
+var _nativeClipboardAPI = false;
+
+try{
+  /* In some browsers, in particular Firefox < 40, queryCommandSupported() will
+   * return true because the command is "supported" in scripts with extra privileges
+   * - but trying to use the API will throw. We use both functions below, but the order
+   * matters: if queryCommandEnabled() throws, we will not use queryCommandSupported().
+   * queryCommandEnabled() is expected to return false when not called from a
+   * user-triggered thread, so it's only called here to see if it throws..
+   */
+  _nativeClipboardAPI = document.queryCommandEnabled("copy") || document.queryCommandSupported("copy");
+}catch(e){}
+
+
+/**
  * Keep track of the state of the Flash object.
  * @private
  */


### PR DESCRIPTION
This pull request aims to make sure we use the native clipboard implementation rather than Flash in browsers with sufficient support for that.

If feature detection indicates native support is available, it will add a simple click event listener rather than a Flash overlay. The click listener will in turn add a copy listener, fire ``execCommand('copy')`` and remove the copy listener again.

It works OK on this test case in the browsers I've tested:
http://hallvord.com/temp/moz/zeroclipboard/test.html
but it could do with much wider testing - more browser/platform combos, Flash enabled/disabled.

@JamesMGreene - review?