### PR TITLE
Accounting for page zoom differences

### DIFF
--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -1622,7 +1622,19 @@ var _getElementPosition = function(el) {
     top: 0,
     width: 0,
     height: 0
-  };
+  },
+  _getPageZoomFactor = function () {
+        var rect, physicalWidth, logicalWidth,
+        zoomFactor = 1.0;
+        if (document.body.getBoundingClientRect) {
+            rect = document.body.getBoundingClientRect();
+            physicalWidth = rect.right - rect.left;
+            logicalWidth = document.body.offsetWidth;
+            zoomFactor = Math.round(physicalWidth / logicalWidth * 100) / 100;
+        }
+        return zoomFactor;
+  },
+  _pageZoomFactor = _getPageZoomFactor();
 
   // Use getBoundingClientRect where available (almost everywhere).
   // See: http://www.quirksmode.org/dom/w3c_cssom.html
@@ -1632,7 +1644,7 @@ var _getElementPosition = function(el) {
 
     // Get the document's scroll offsets
     var pageXOffset = _window.pageXOffset;
-    var pageYOffset = _window.pageYOffset;
+    var pageYOffset = Math.round(_window.pageYOffset / _pageZoomFactor);
 
     // `clientLeft`/`clientTop` are to fix IE's 2px offset in standards mode
     var leftBorderWidth = _document.documentElement.clientLeft || 0;
@@ -1650,9 +1662,9 @@ var _getElementPosition = function(el) {
     }
 
     pos.left = elRect.left + pageXOffset - leftBorderWidth - leftBodyOffset;
-    pos.top = elRect.top + pageYOffset - topBorderWidth - topBodyOffset;
-    pos.width = "width" in elRect ? elRect.width : elRect.right - elRect.left;
-    pos.height = "height" in elRect ? elRect.height : elRect.bottom - elRect.top;
+    pos.top = Math.round((elRect.top + pageYOffset - topBorderWidth - topBodyOffset) / _pageZoomFactor);
+    pos.width = Math.round(("width" in elRect ? elRect.width : elRect.right - elRect.left) / _pageZoomFactor);
+    pos.height = Math.round(("height" in elRect ? elRect.height : elRect.bottom - elRect.top) / _pageZoomFactor);
   }
 
   return pos;

--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -1611,6 +1611,27 @@ var _getStyle = function(el, prop) {
 
 
 /**
+ * Get the current zoom factor for the page. Calculates the zoom factor by
+ * determining the width of the body as reported without scaling divided by
+ * the width of the body including CSS rules.
+ *
+ * @returns Float representing the zoom factor.
+ * @private
+ */
+var _getPageZoomFactor = function () {
+  var rect, physicalWidth, logicalWidth,
+  zoomFactor = 1.0;
+  if (document.body.getBoundingClientRect) {
+      rect = document.body.getBoundingClientRect();
+      physicalWidth = rect.right - rect.left;
+      logicalWidth = document.body.offsetWidth;
+      zoomFactor = Math.round(physicalWidth / logicalWidth * 100) / 100;
+  }
+  return zoomFactor;
+};
+
+
+/**
  * Get the absolutely positioned coordinates of a DOM element.
  *
  * @returns Object containing the element's position, width, and height.
@@ -1622,17 +1643,6 @@ var _getElementPosition = function(el) {
     top: 0,
     width: 0,
     height: 0
-  },
-  _getPageZoomFactor = function () {
-        var rect, physicalWidth, logicalWidth,
-        zoomFactor = 1.0;
-        if (document.body.getBoundingClientRect) {
-            rect = document.body.getBoundingClientRect();
-            physicalWidth = rect.right - rect.left;
-            logicalWidth = document.body.offsetWidth;
-            zoomFactor = Math.round(physicalWidth / logicalWidth * 100) / 100;
-        }
-        return zoomFactor;
   },
   _pageZoomFactor = _getPageZoomFactor();
 

--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -1644,7 +1644,7 @@ var _getElementPosition = function(el) {
     width: 0,
     height: 0
   },
-  _pageZoomFactor = _getPageZoomFactor();
+  pageZoomFactor = _getPageZoomFactor();
 
   // Use getBoundingClientRect where available (almost everywhere).
   // See: http://www.quirksmode.org/dom/w3c_cssom.html
@@ -1654,7 +1654,7 @@ var _getElementPosition = function(el) {
 
     // Get the document's scroll offsets
     var pageXOffset = _window.pageXOffset;
-    var pageYOffset = Math.round(_window.pageYOffset / _pageZoomFactor);
+    var pageYOffset = Math.round(_window.pageYOffset / pageZoomFactor);
 
     // `clientLeft`/`clientTop` are to fix IE's 2px offset in standards mode
     var leftBorderWidth = _document.documentElement.clientLeft || 0;
@@ -1672,9 +1672,9 @@ var _getElementPosition = function(el) {
     }
 
     pos.left = elRect.left + pageXOffset - leftBorderWidth - leftBodyOffset;
-    pos.top = Math.round((elRect.top + pageYOffset - topBorderWidth - topBodyOffset) / _pageZoomFactor);
-    pos.width = Math.round(("width" in elRect ? elRect.width : elRect.right - elRect.left) / _pageZoomFactor);
-    pos.height = Math.round(("height" in elRect ? elRect.height : elRect.bottom - elRect.top) / _pageZoomFactor);
+    pos.top = Math.round((elRect.top + pageYOffset - topBorderWidth - topBodyOffset) / pageZoomFactor);
+    pos.width = Math.round(("width" in elRect ? elRect.width : elRect.right - elRect.left) / pageZoomFactor);
+    pos.height = Math.round(("height" in elRect ? elRect.height : elRect.bottom - elRect.top) / pageZoomFactor);
   }
 
   return pos;

--- a/src/js/core/private.js
+++ b/src/js/core/private.js
@@ -1621,10 +1621,10 @@ var _getStyle = function(el, prop) {
 var _getPageZoomFactor = function () {
   var rect, physicalWidth, logicalWidth,
   zoomFactor = 1.0;
-  if (document.body.getBoundingClientRect) {
-      rect = document.body.getBoundingClientRect();
+  if (_document.body.getBoundingClientRect) {
+      rect = _document.body.getBoundingClientRect();
       physicalWidth = rect.right - rect.left;
-      logicalWidth = document.body.offsetWidth;
+      logicalWidth = _document.body.offsetWidth;
       zoomFactor = Math.round(physicalWidth / logicalWidth * 100) / 100;
   }
   return zoomFactor;


### PR DESCRIPTION
Attempted fix for issue #149.

This "fix" works for pages scaled with a `transform` CSS property, using some of @JamesMGreene's code from JSFiddle (link below). This does not appear to affect positioning on unscaled pages.

**Warning: It has not been thoroughly tested against other types of transforms, scale rules, etc.**

JSFiddle link:
http://jsfiddle.net/JamesMGreene/cDqXE/

Example CSS rules that this works for:

``` css
@media (min-width: 768px) {
    body {
        transform: scale(0.75);
        -webkit-transform: scale(0.75);
        -moz-transform: scale(0.75);
        -ms-transform: scale(0.75);
        transform-origin: center 0;
        -webkit-transform-origin: center 0;
        -moz-transform-origin: center 0;
        -ms-transform-origin: center 0;

    }
}
```

Steps to test:
1. Set up zeroclipboard on test page.
2. Apply transform CSS rule similar to above.
3. Verify that the zeroclipboard Flash object is correctly positioned over the target element.
